### PR TITLE
Add extra generation params to image information when features are used

### DIFF
--- a/scripts/latent_mirroring.py
+++ b/scripts/latent_mirroring.py
@@ -72,23 +72,25 @@ class Script(scripts.Script):
 
 
     def process(self, p, mirror_mode, mirror_style, x_pan, y_pan, mirroring_max_step_fraction):
-        if mirror_mode != 0:
-            self.mirror_mode = mirror_mode
-            self.mirror_style = mirror_style
-            self.mirroring_max_step_fraction = mirroring_max_step_fraction
-            self.x_pan = x_pan
-            self.y_pan = y_pan
+        self.mirror_mode = mirror_mode
+        self.mirror_style = mirror_style
+        self.mirroring_max_step_fraction = mirroring_max_step_fraction
+        self.x_pan = x_pan
+        self.y_pan = y_pan
 
+        if mirror_mode != 0:
             p.extra_generation_params["Mirror Mode"] = mirror_mode
             p.extra_generation_params["Mirror Style"] = mirror_style
-            p.extra_generation_params["Mirror Max Step Fraction"] = mirroring_max_step_fraction
-            p.extra_generation_params["Mirror X Pan"] = x_pan
-            p.extra_generation_params["Mirror Y Pan"] = y_pan
+            p.extra_generation_params["Mirroring Max Step Fraction"] = mirroring_max_step_fraction
+        if x_pan != 0:
+            p.extra_generation_params["X Pan"] = x_pan
+        if y_pan != 0:
+            p.extra_generation_params["Y Pan"] = y_pan
 
-            if not hasattr(self, 'callbacks_added'):
-                on_cfg_denoiser(self.denoise_callback)
-                self.callbacks_added = True
-            self.run_callback = True
+        if not hasattr(self, 'callbacks_added'):
+            on_cfg_denoiser(self.denoise_callback)
+            self.callbacks_added = True
+        self.run_callback = True
 
     def postprocess(self, *args):
         self.run_callback = False

--- a/scripts/latent_mirroring.py
+++ b/scripts/latent_mirroring.py
@@ -72,16 +72,23 @@ class Script(scripts.Script):
 
 
     def process(self, p, mirror_mode, mirror_style, x_pan, y_pan, mirroring_max_step_fraction):
-        self.mirror_mode = mirror_mode
-        self.mirror_style = mirror_style
-        self.mirroring_max_step_fraction = mirroring_max_step_fraction
-        self.x_pan = x_pan
-        self.y_pan = y_pan
+        if mirror_mode != 0:
+            self.mirror_mode = mirror_mode
+            self.mirror_style = mirror_style
+            self.mirroring_max_step_fraction = mirroring_max_step_fraction
+            self.x_pan = x_pan
+            self.y_pan = y_pan
 
-        if not hasattr(self, 'callbacks_added'):
-            on_cfg_denoiser(self.denoise_callback)
-            self.callbacks_added = True
-        self.run_callback = True
+            p.extra_generation_params["Mirror Mode"] = mirror_mode
+            p.extra_generation_params["Mirror Style"] = mirror_style
+            p.extra_generation_params["Mirror Max Step Fraction"] = mirroring_max_step_fraction
+            p.extra_generation_params["Mirror X Pan"] = x_pan
+            p.extra_generation_params["Mirror Y Pan"] = y_pan
+
+            if not hasattr(self, 'callbacks_added'):
+                on_cfg_denoiser(self.denoise_callback)
+                self.callbacks_added = True
+            self.run_callback = True
 
     def postprocess(self, *args):
         self.run_callback = False


### PR DESCRIPTION
Hello! Thank you for creating this extension, it is fun to work with!

It would be nice to save the latent mirroring generation parameters for future reference or to recreate a previous image. I added them using extra_generation_params.

I also found that when mirror_mode = 0 (None) that the parameters were still saved. So I made the body of process() only run when mirror_mode is enabled. This change also happens to fix a bug when mirror_mode is None:

Before this commit, if you generate an image with (mirror_mode == 0 "None") and (x_pan or y_pan not set to default value of 0) the image generation will be affected.

Feel free to make any edits if you would like to improve this in a different way :)